### PR TITLE
Support http verb Patch.

### DIFF
--- a/ARMClient.Authentication/Utilities/Utils.cs
+++ b/ARMClient.Authentication/Utilities/Utils.cs
@@ -86,6 +86,14 @@ namespace ARMClient.Authentication.Utilities
                 {
                     response = await client.PutAsync(uri, content);
                 }
+                else if (String.Equals(verb, "patch", StringComparison.OrdinalIgnoreCase))
+                {
+                    using (var message = new HttpRequestMessage(new HttpMethod("PATCH"), uri))
+                    {
+                        message.Content = content;
+                        response = await client.SendAsync(message).ConfigureAwait(false);
+                    }
+                }
                 else
                 {
                     throw new InvalidOperationException(String.Format("Invalid http verb {0}!", verb));

--- a/ARMClient.Console/Program.cs
+++ b/ARMClient.Console/Program.cs
@@ -116,7 +116,8 @@ namespace ARMClient
                     else if (String.Equals(verb, "get", StringComparison.OrdinalIgnoreCase)
                         || String.Equals(verb, "delete", StringComparison.OrdinalIgnoreCase)
                         || String.Equals(verb, "put", StringComparison.OrdinalIgnoreCase)
-                        || String.Equals(verb, "post", StringComparison.OrdinalIgnoreCase))
+                        || String.Equals(verb, "post", StringComparison.OrdinalIgnoreCase)
+                        || String.Equals(verb, "patch", StringComparison.OrdinalIgnoreCase))
                     {
                         var path = _parameters.Get(1, keyName: "url");
                         var verbose = _parameters.Get("-verbose", requires: false) != null || Utils.GetDefaultVerbose();

--- a/ARMClient.Library/ARMLib.cs
+++ b/ARMClient.Library/ARMLib.cs
@@ -101,6 +101,13 @@ namespace ARMClient.Library
             return await httpResponse.Content.ReadAsAsync<T>().ConfigureAwait(false);
         }
 
+        public async Task<T> PatchAsync<T>(params object[] args)
+        {
+            var httpResponse = await HttpInvoke("Patch", args).ConfigureAwait(false);
+            httpResponse.EnsureSuccessStatusCode();
+            return await httpResponse.Content.ReadAsAsync<T>().ConfigureAwait(false);
+        }
+
         public async Task<T> DeleteAsync<T>()
         {
             var httpResponse = await HttpInvoke("Delete", Enumerable.Empty<object>().ToArray()).ConfigureAwait(false);
@@ -181,6 +188,14 @@ namespace ARMClient.Library
                 else if (String.Equals(verb, "put", StringComparison.OrdinalIgnoreCase))
                 {
                     response = await client.PutAsync(uri, new StringContent(payload ?? String.Empty, Encoding.UTF8, Constants.JsonContentType)).ConfigureAwait(false);
+                }
+                else if (String.Equals(verb, "patch", StringComparison.OrdinalIgnoreCase))
+                {
+                    using (var message = new HttpRequestMessage(new HttpMethod("PATCH"), uri))
+                    {
+                        message.Content = new StringContent(payload ?? String.Empty, Encoding.UTF8, Constants.JsonContentType);
+                        response = await client.SendAsync(message).ConfigureAwait(false);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Add support for http patch. This allows ARMClient to patch a resource, e.g. adding/removing tags.