### PR TITLE
Readme update for powershell users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ Check out [wiki](https://github.com/projectkudu/ARMClient/wiki) for more details
     Clear token cache
         ARMClient.exe clearcache
 
-Note: The tokens are cached at `%USERPROFILE%\.arm` folder.  All files are encrypted with CurrentUser ProtectData .NET api.  
+Note: The tokens are cached at `%USERPROFILE%\.arm` folder.  All files are encrypted with CurrentUser ProtectData .NET api. 
+
+Note: PowerShell users will need to escape the `@` symbol with a back tick <code>`</code>.
 
 ARMClient.Library.ARMClient
 ============================


### PR DESCRIPTION
PowerShell holds special meaning for the @ symbol, and thus will need to be escaped `@