### PR TITLE
(bug) fixes guid validation for tenant ID

### DIFF
--- a/ARMClient.Console/Program.cs
+++ b/ARMClient.Console/Program.cs
@@ -85,7 +85,6 @@ namespace ARMClient
                     else if (String.Equals(verb, "spn", StringComparison.OrdinalIgnoreCase))
                     {
                         var tenantId = _parameters.Get(1, keyName: "tenant");
-                        EnsureGuidFormat(tenantId);
                         var appId = _parameters.Get(2, keyName: "appId");
                         EnsureGuidFormat(appId);
 


### PR DESCRIPTION
addresses issue #20 - tenantID does not need to be a GUID for AAD authentication.
